### PR TITLE
Fixed potential syntax error for get_table_names

### DIFF
--- a/deployment/workflow.yaml
+++ b/deployment/workflow.yaml
@@ -77,7 +77,7 @@
                       body:
                           useLegacySql: false
                           projectId: $${source_project_id}
-                          query: $${"SELECT table_name FROM " + source_dataset_id + ".INFORMATION_SCHEMA.TABLES WHERE table_name LIKE '" + source_table_name + "' ORDER BY creation_time DESC LIMIT " + config_json_content.body.source_table.n_tables_to_check }
+                          query: $${"SELECT table_name FROM `" + source_dataset_id + ".INFORMATION_SCHEMA.TABLES` WHERE table_name LIKE '" + source_table_name + "' ORDER BY creation_time DESC LIMIT " + config_json_content.body.source_table.n_tables_to_check }
                   result: queryResult
               - table_loop:
                   parallel:


### PR DESCRIPTION
In some cases the dataset id can throw a syntax error:
Syntax error: Missing whitespace between literal and alias at [1:25]

Dataset ID example that will fail: 1dataset

Fix: Added `` around (" + source_dataset_id + ".INFORMATION_SCHEMA.TABLES)